### PR TITLE
商品一覧機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.all.order("created_at DESC")
+    
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.order("created_at DESC")
     
   end
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -144,7 +144,7 @@
                   <%= item.name %>
                 </h3>
                 <div class='item-price'>
-                  <span><%= item.price %>円<br><%#= item.shipping_fee_burden_id %></span>
+                  <span><%= item.price %>円<br><%= item.shipping_fee_burden.name %></span>
                   <div class='star-btn'>
                     <%= image_tag "star.png", class:"star-icon" %>
                     <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,37 +127,38 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
+      <% if @items.present? %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to item_path(item.id) do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: 'item-image' %>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+                <%# //商品が売れていればsold outを表示しましょう %>
+              </div>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br><%#= item.shipping_fee_burden_id %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </li>
         <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+        <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <%# if @items == 0 %>
+        <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+        <%# 商品がある場合は表示されないようにしましょう %>
+      <% else %>  
         <li class='list'>
           <%= link_to '#' do %>
           <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -173,11 +174,11 @@
               </div>
             </div>
           </div>
-          <% end %>
-        </li>
-      <%# end %>  
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は上記のダミー商品が表示されるようにしましょう %>
+        </li> 
+        <% end %>
+        <%# //商品がある場合は表示されないようにしましょう %>
+        <%# //商品がない場合は上記のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
           <li class='list'>
             <%= link_to item_path(item.id) do %>
               <div class='item-img-content'>
-                <%= image_tag item.image, class: 'item-image' %>
+                <%= image_tag item.image, class: 'item-img' %>
                 <%# 商品が売れていればsold outを表示しましょう %>
                 <div class='sold-out'>
                   <span>Sold Out!!</span>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -20,7 +20,7 @@
           クリックしてファイルをアップロード
         </p>
         <%= f.file_field :image, id:"item-image" %>
-        <%= image_tag @item.image.variant(resize: '500x500'), class: 'item-image' if @item.image.attached? %>
+        <%= image_tag @item.image.variant(resize: '300x300') ,class:"item-box-img" if @item.image.attached? %>
       </div>
     </div>
     <%# /出品画像 %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -20,7 +20,7 @@
           クリックしてファイルをアップロード
         </p>
         <%= f.file_field :image, id:"item-image" %>
-        <%= image_tag @item.image.variant(resize: '300x300') ,class:"item-box-img" if @item.image.attached? %>
+        <%= image_tag @item.image.variant(resize: '300x300') ,class:"item-img" if @item.image.attached? %>
       </div>
     </div>
     <%# /出品画像 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,12 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%#= @item.name %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image.variant(resize: '300x300') ,class:"item-box-img" if @item.image.attached? %>
+
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,10 +18,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%#= @item.price%>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%#= @item.shipping_fee_burden %>
       </span>
     </div>
 
@@ -37,7 +39,7 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# Why
出品した商品を表示させるため

・出品数がない場合、ダミー商品を表示させる
https://i.gyazo.com/7d7bde91b1010321dbc7fbb9825756a2.gif

・１品目の出品 (商品の画像、名前、値段が表示されている)
https://i.gyazo.com/8410dcad8f2368be65518e0507feeaac.gif

・２品目の出品/新しい商品から表示される
https://i.gyazo.com/807752d5bcb4ae3bc71779af590b11f4.gif

・ロウアウトの状態でも、出品された商品が表示される
https://i.gyazo.com/eedc3735fd3aa624a2d34016903dc559.gif

以上、ご確認よろしくお願い致します。