### PR TITLE
商品詳細ページの実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.order("created_at DESC")
@@ -17,6 +17,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,6 +3,7 @@ class Item < ApplicationRecord
 
   belongs_to :user
   belongs_to :condition
+  belongs_to :category
   belongs_to :prefecture
   belongs_to :shipping_date
   belongs_to :shipping_fee_burden

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,9 +134,9 @@
               <div class='item-img-content'>
                 <%= image_tag item.image, class: 'item-img' %>
                 <%# 商品が売れていればsold outを表示しましょう %>
-                <div class='sold-out'>
+                <%#<div class='sold-out'>
                   <span>Sold Out!!</span>
-                </div>
+                </div>%>
                 <%# //商品が売れていればsold outを表示しましょう %>
               </div>
               <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,38 +4,39 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%#= @item.name %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%#= image_tag "item-sample.png" ,class:"item-box-img" %>
       <%= image_tag @item.image.variant(resize: '300x300') ,class:"item-box-img" if @item.image.attached? %>
 
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%#<div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div>%>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥<%#= @item.price%>
+        ¥<%= @item.price%>
       </span>
       <span class="item-postage">
-        <%#= @item.shipping_fee_burden %>
+        <%= @item.shipping_fee_burden.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% else %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <% end  %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
@@ -45,27 +46,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_date.name %></td>
         </tr>
       </tbody>
     </table>
@@ -105,7 +106,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href=“#” class=‘another-item’><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href=“#” class=‘another-item’><%= "@item.category.name" %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%#= image_tag "item-sample.png" ,class:"item-box-img" %>
+
       <%= image_tag @item.image.variant(resize: '300x300') ,class:"item-box-img" if @item.image.attached? %>
 
       <%# 商品が売れている場合は、sold outを表示しましょう %>


### PR DESCRIPTION
# What
商品詳細表示の実装

# Why
商品詳細表示ページの実装のため

・ログアウト状態でも、商品の詳細ページに遷移できる/編集・削除・購入ボタンの表示はされない
https://i.gyazo.com/13b1af1c171c6c2fe5f3ffffbe64af58.gif

・出品者以外のユーザーは詳細ページに購入ボタンが表示される
https://i.gyazo.com/3b4fd4647dd24a00e2a90700045a1960.gif

・出品者のみ、詳細ページに編集・削除ボタンが表示される
https://i.gyazo.com/8698382866652200220502c67c879217.gif

# Attention
商品が購入された時の表示は購入機能の実装時に記述する予定です。

以上、ご確認よろしくお願い致します。